### PR TITLE
Refactored Vagrantfile and site.yml

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -2,6 +2,8 @@
 ---
 - name: Install/configure solr server
   hosts: "{{host_inventory}}"
+  vars_files:
+    - vars/solr.yml
   vars:
     - combined_package_list: "{{ (default_packages|default([])) | union(solr_package_list) | union((install_packages_by_tag|default({})).solr|default([])) }}"
   roles:


### PR DESCRIPTION
The changes in this pull request refactor the `Vagrantfile` and `site.yml` file in order to pull in default values for deployment of kafka from the newly created `vars/solr.yml` file and to support additional vagrant flags.  Specifically:

* the `site.yml` file was changed to pull in the `vars/solr.yml` file (in order to retrieve the default values for the parameters that *must* be defined to successfully deploy LucidWorks Fusion (Solr) using the Ansible playbook defined in the `site.yml` file)
* Code was added to the `Vagrantfile` to monkey-patch the `OptionParser` class used to parse the command-line flags passed to the `vagrant ...` commands; the modified code passes any unrecognized options on to the underlying `vagrant` command so that the `--no-provision` flag can be passed to a `vagrant up ...` command to create, but not provision a new virtual machine.
* Changes were made to the `Vagrantfile` to remove a couple of values that we used to set locally in the `Vagrantfile` but which are now set in the `vars/solr.yml` file (we now accept the default values in that file for those two parameters rather than redefining those same default values in the `Vagrantfile`)

With these changes in place, we should be ready to wrap the deployment of LucidWorks Fusion (Solr) via Vagrant in the same install wrapper that we are currently using to deploy applications to AWS instances.