### PR TITLE
Updating README.md and Vagrantfile to reflect the latest usage options

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,30 +3,81 @@ Playbooks/Roles used to deploy LucidWorks Fusion (Solr)
 
 # Installation
 To install solr using the `site.yml` playbook in this repository, first clone the contents of this repository to a local directory using a command like the following:
+
 ```bash
 $ git clone --recursive https://github.com/Datanexus/dn-solr
 ```
+
 That command will pull down the repository and it's submodules (currently the only dependency embedded as a submodule is the dependency on the `https://github.com/Datanexus/common-roles` repository).
 
-# Use
-To run the included playbook, change directories to the `dn-solr` subdirectory and run a set of commands that look something like the following (the commands shown here will install the most recent version of the LucidWorks Fusion (Solr)  distribution from the LucidWorks software repository, for example, onto a machine with at the IP address "192.168.34.12"):
-```bash
-$ export SOLR_URL="https://download.lucidworks.com/fusion-2.4.4.tar.gz"
-$ export SOLR_ADDR="192.168.34.12"
-$ export SOLR_DIR="/opt/fusion"
-$ export SOLR_PACKAGE_LIST='["java-1.8.0-openjdk", "java-1.8.0-openjdk-devel"]'
-$ echo "[all]\n${SOLR_ADDR}" > hosts
-$ ansible-playbook site.yml --inventory-file hosts --extra-vars "solr_url=${SOLR_URL} \
-    solr_addr=${SOLR_ADDR} solr_dir=${SOLR_DIR} solr_package_list=${SOLR_PACKAGE_LIST}"
+# Using this role to deploy Solr
+The `site.yml` file at the top-level of this repository pulls in a set of default values for the parameters that are needed to deploy an instance of the LucidWorks Fusion (Solr) distribution to a node from the `vars/solr.yml` file.  The contents of that file currently look like this:
+
+```yaml
+# (c) 2016 DataNexus Inc.  All Rights Reserved
+#
+# Defaults that are necessary for all deployments of
+# LucidWorks Fusion (Solr)
+---
+application: solr
+solr_url: "https://download.lucidworks.com/fusion-2.4.4.tar.gz"
+solr_dir: "/opt/fusion"
+solr_package_list: ["java-1.8.0-openjdk", "java-1.8.0-openjdk-devel"]
 ```
-All of the variables shown in this example must be defined for the playbook to run successfully.
+
+This default configuration defines default values for all of the parameters needed to deploy an instance of Solr to a node, including defining reasonable defaults for the URL that the Fusion distribution should be downloaded from, the directory that the gzipped tarfile containing the Fusion distribution should be unpacked into, and the packages that must be installed on the node for Fusion to run.  To deploy Solr to a node the IP address "192.168.34.12" using the role in this repository, one would simply run a command that looks like this:
+
+```bash
+$ export SOLR_ADDR="192.168.34.12"
+$ ansible-playbook -i "${SOLR_ADDR}," -e "{ host_inventory: ['${SOLR_ADDR}']}" site.yml
+```
+
+This will download the distribution from the main LucidWorks Fusion download site onto the host with an IP address of 192.168.34.12, unpack the gzipped tarfile that it downlaoded form that site into the `/opt/fusion` directory on that host, and install/configure the Solr server locally on that host.
+
+Unfortunately, the main LucidWorks download site is often quite busy (and very slow as a result), so in our experience it has been a much better option to download the gzipped tarfile containing the Fusion distribution from that site once, then post it on a local webserver (one that is only available internally) and download it from the nodes we are setting up as Solr servers from that internal web server.  This can be accomplished by also including a definition for the `solr_url` parameter in the extra variables that are passed into the Ansible playbook run.  In that case, the command shown above ends up looking something like this:
+
+```bash
+$ export SOLR_URL="https://10.0.2.2/fusion-2.4.4.tar.gz"
+$ export SOLR_ADDR="192.168.34.12"
+$ ansible-playbook -i "${SOLR_ADDR}," -e "{ host_inventory: ['${SOLR_ADDR}'] \
+    solr_url: '${SOLR_URL}'}" site.yml
+```
+
+(assuming that the file is available directly from a web-server that is accessible from the Solr server we are building via the IP address 10.0.2.2).  The path that the Solr distribution is unpacked into can also be overriden on the command-line in a similar fashion (using the `solr_path` variable) if the default values shown in the `vars/solr.yml` file (above) proves to be problematic.
 
 # Assumptions
 It is assumed that this playbook will be run on a recent (systemd-based) version of RHEL or CentOS (RHEL-7.x or CentOS-7.x, for example); no support is provided for other distributions (and the `site.xml` playbook will not run successfully).  The examples shown above also assume that some (shared-key?) mechanism has been used to provide access to the Kafka host from the Ansible host that the ansible-playbook is being run on (if not, then additional arguments might be required to authenticate with that host from the Ansible host that are not shown in the example `ansible-playbook` commands shown above).
 
 # Deployment via vagrant
-The included Vagrantfile can be used to deploy LucidWorks Fusion (Solr) to a VM using `Vagrant`.  From the top-level directory of this repostory a command like the following will (by default) deploy kafka to a CentOS 7 virtual machine running under VirtualBox (assuming that both vagrant and VirtualBox are installed locally, of course):
+A Vagrantfile is included in this repository that can be used to deploy Solr to a VM using the `vagrant` command.  From the top-level directory of this repository a command like the following will (by default) deploy Solr to a CentOS 7 virtual machine running under VirtualBox (assuming that both vagrant and VirtualBox are installed locally, of course):
+
 ```bash
-$ VAGRANT_DEFAULT_PROVIDER=virtualbox vagrant -s="192.168.34.12" up
+$ vagrant -s="192.168.34.12" up
 ```
-Note that the `-s` (or the corresponding `--solr-addr`) flag must be used to pass an IP address into the Vagrantfile (this IP address will be used as the IP address of the Solr server that is created by the vagrant command shown above).  The Vagrantfile also includes a definition for a `solr_url` variable that can be updated to point to the gzipped tarfile containing the LucidWorks Fusion (Solr) distribution if you are interested in downloading that file from another source (the Vagrantfile included in the current repository assumes this file can be downloaded from a web server running on the localhost where the `vagrant up` command was run from).
+
+Note that the `-s` (or the corresponding `--solr-addr`) flag must be used to pass an IP address into the Vagrantfile (this IP address will be used as the IP address of the Solr server that is created by the vagrant command shown above).
+
+## Additional vagrant deployment options
+While the `vagrant up` command that is shown above can be used to easily deploy Solr to a node, the Vagrantfile included in this distribution also supports separating out the creation of the virtual machine from the provisioning of that virtual machine using the Ansible playbook contained in this repository's `site.yml` file. To create a virtual machine without provisioning it, simply run a command that looks something like this:
+
+```bash
+$ vagrant -s="192.168.34.12" up --no-provision
+```
+
+This will create a virtual machine with the appropriate IP address ("192.168.34.12"), but will skip the process of provisioning that VM with an instance of Solr using the playbook in the `site.yml` file.  To provision that machine with a Solr instance, you would simply run the following command:
+
+```bash
+$ vagrant -s="192.168.34.12" provision
+```
+
+That command will attach to the named instance (the VM at "192.168.34.12") and run the playbook in this repository's `site.yml` file on that node (resulting in the deployment of an instance the LucidWorks Fusion distribution of Solr to that node).
+
+It should also be noted here that while the commands shown above will install Solr with a reasonable default configuration from a standard location, there are two additional command-line parameters that can be used to override the default values that are embedded in the `vars/solr.yml` file that is included as part of this repository:  the `-u` (or corresponding `--url`) flag and the `-p` (or corresponding `--path`) flag.  The `-u` flag can be used to override the default URL that is used to download the LucidWorks Fusion (Solr) distribution (which points back to the main LucidWorks distribution site), while the `-p` flag can be used to override the default path (`/opt/fusion`) that that the LucidWorks Fusion gzipped tarfile is unpacked into during the provisioning process.
+
+As an example of how these options might be used, the following command will download the gzipped tarfile containing the LucidWorks Fusion distribution from a local web server, rather than downloading it from the main LucidWorks distribution site and unpack the downladed gzipped tarfile into the `/opt/solr` directory when provisioning the VM with an IP address of `192.168.34.12` with an instance of the LucidWorks Fusion distribution:
+
+```bash
+$ vagrant -k="192.168.34.12" -p="/opt/solr" -u="https://10.0.2.2/fusion-2.4.4.tar.gz" provision
+```
+
+Obviously, this option could prove to be quite useful in situations were we are deploying the distribution from a datacenter environment (where access to the internet may be restricted, or even unavailable).

--- a/vars/solr.yml
+++ b/vars/solr.yml
@@ -5,6 +5,5 @@
 ---
 application: solr
 solr_url: "https://download.lucidworks.com/fusion-2.4.4.tar.gz"
-# solr_url: "https://10.0.2.2/fusion-2.4.4.tar.gz"
 solr_dir: "/opt/fusion"
 solr_package_list: ["java-1.8.0-openjdk", "java-1.8.0-openjdk-devel"]


### PR DESCRIPTION
The changes in this pull request update the `README.md` file and the `Vagrantfile` in this repository to reflect what we hope will be the last round of changes needed to make the repository more generally useful; specifically:

* the `Vagrantfile` has been updated so that a small set of `vagrant` commands can be run without specifying a Kafka IP address (using the `-s` or `--solr-addr` flag); this list is currently limited to the `version`, `global-status`, `--help`, and `-h` vagrant commands.
* the `Vagrantfile` has been updated to include two new flags (the `-u` and corresponding `--url` flag and the `-p` and corresponding `--path` flags) which can be used to specify the URL to use when downloading the gzipped tarfile containing the LucidWorks Fusion (Solr) distribution and the path that gzipped tarfile should be unpacked into, respectively.
* the error handling in the `Vagrantfile` has been updated to only throw an error when necessary; previously there were situations were the error exits were not handled correctly and spurious errors were reported (rather than exiting smoothly with a usage message as was intended)
* the default values that were previously declared for deployments of both the Apache and Confluent Kafka distributions in the `Vagrantfile` have been removed since those same values are now pulled in directly from the `vars/kafka.yml` file (see below for more details on that).
* the `vars/kafka.yml` file has been changed to declare reasonable defaults for all of the parameters needed to deploy either the Apache Kafka distribution or the Confluent Kafka distribution to a node.  The distribution that is deployed by default remains as the Confluent Kafka distribution but, if that value is overridden on the command line, the default values needed to deploy the Apache Kafka distribution are already specified (so only one parameter needs to be redefined to switch distributions).  The layout of this file has also been reorganized and comments have been added to help the user if they need to hand-edit this file for some reason.
* the `README.md` file has been changed to reflect the new ways of deploying the LucidWorks Fusion (Solr) distribution to a node using either the playbook contained in the `site.yml` file in this repository or the `Vagrantfile`.  We have also added a section to the `README.md` file that discusses how the `vagrant ... up --no-provision` and `vagrant ... provision` commands can now be used to create a new virtual machine without provisioning an instance of Solr to it, then provision Solr to that node (respectively).  This change is needed to support wrapping of this role in a pair of playbooks similar to those used when deploying this application to an instance running in an AWS environment.

With these changes in place, this role should now be more generally usable.