### PR TITLE
Adds ability to provision multi-node Fusion clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,21 @@ The `site.yml` file at the top-level of this repository pulls in a set of defaul
 # LucidWorks Fusion (Solr)
 ---
 application: solr
-solr_url: "https://download.lucidworks.com/fusion-2.4.4.tar.gz"
-solr_dir: "/opt/fusion"
+# the URL that should be used to download the Fusion (Solr) distribution
+# (Fusion is distributed as a gzipped tarfile)
+solr_url: "https://download.lucidworks.com/fusion-3.0.0.tar.gz"
+# the directory where the solr data will be written
+solr_data_dir: /opt/lucidworks/data
+# the interface Fusion (Solr) should listen on when running
+solr_iface: eth0
+# the directory that the distribution should be unpacked into
+solr_dir: "/opt/lucidworks"
+# the packages that need to be installed for Solr nodes (the JRE and JDK
+# packages from the OpenJDK project)
 solr_package_list: ["java-1.8.0-openjdk", "java-1.8.0-openjdk-devel"]
+# used to install Fusion (Solr) from a local (to the Ansible node) gzipped
+# tarfile (if it exists)
+local_solr_file: ""
 ```
 
 This default configuration defines default values for all of the parameters needed to deploy an instance of Solr to a node, including defining reasonable defaults for the URL that the Fusion distribution should be downloaded from, the directory that the gzipped tarfile containing the Fusion distribution should be unpacked into, and the packages that must be installed on the node for Fusion to run.  To deploy Solr to a node the IP address "192.168.34.12" using the role in this repository, one would simply run a command that looks like this:
@@ -32,18 +44,18 @@ $ export SOLR_ADDR="192.168.34.12"
 $ ansible-playbook -i "${SOLR_ADDR}," -e "{ host_inventory: ['${SOLR_ADDR}']}" site.yml
 ```
 
-This will download the distribution from the main LucidWorks Fusion download site onto the host with an IP address of 192.168.34.12, unpack the gzipped tarfile that it downlaoded form that site into the `/opt/fusion` directory on that host, and install/configure the Solr server locally on that host.
+This will download the distribution from the main LucidWorks Fusion download site onto the host with an IP address of 192.168.34.12, unpack the gzipped tarfile that it downlaoded form that site into the `/opt/lucidworks` directory on that host, and install/configure the Solr server locally on that host.
 
 Unfortunately, the main LucidWorks download site is often quite busy (and very slow as a result), so in our experience it has been a much better option to download the gzipped tarfile containing the Fusion distribution from that site once, then post it on a local webserver (one that is only available internally) and download it from the nodes we are setting up as Solr servers from that internal web server.  This can be accomplished by also including a definition for the `solr_url` parameter in the extra variables that are passed into the Ansible playbook run.  In that case, the command shown above ends up looking something like this:
 
 ```bash
-$ export SOLR_URL="https://10.0.2.2/fusion-2.4.4.tar.gz"
+$ export SOLR_URL="https://10.0.2.2/fusion-3.0.0.tar.gz"
 $ export SOLR_ADDR="192.168.34.12"
 $ ansible-playbook -i "${SOLR_ADDR}," -e "{ host_inventory: ['${SOLR_ADDR}'] \
     solr_url: '${SOLR_URL}'}" site.yml
 ```
 
-(assuming that the file is available directly from a web-server that is accessible from the Solr server we are building via the IP address 10.0.2.2).  The path that the Solr distribution is unpacked into can also be overriden on the command-line in a similar fashion (using the `solr_path` variable) if the default values shown in the `vars/solr.yml` file (above) proves to be problematic.
+(assuming that the file is available directly from a web-server that is accessible from the Solr server we are building via the IP address 10.0.2.2).  The path that the Solr distribution is unpacked into can also be overriden on the command-line in a similar fashion (using the `solr_dir` variable) if the default values shown in the `vars/solr.yml` file (above) proves to be problematic.
 
 # Assumptions
 It is assumed that this playbook will be run on a recent (systemd-based) version of RHEL or CentOS (RHEL-7.x or CentOS-7.x, for example); no support is provided for other distributions (and the `site.xml` playbook will not run successfully).  The examples shown above also assume that some (shared-key?) mechanism has been used to provide access to the Kafka host from the Ansible host that the ansible-playbook is being run on (if not, then additional arguments might be required to authenticate with that host from the Ansible host that are not shown in the example `ansible-playbook` commands shown above).
@@ -55,7 +67,7 @@ A Vagrantfile is included in this repository that can be used to deploy Solr to 
 $ vagrant -s="192.168.34.12" up
 ```
 
-Note that the `-s` (or the corresponding `--solr-addr`) flag must be used to pass an IP address into the Vagrantfile (this IP address will be used as the IP address of the Solr server that is created by the vagrant command shown above).
+Note that the `-s` (or the corresponding `--solr-list`) flag must be used to pass an IP address into the Vagrantfile (this IP address will be used as the IP address of the Solr server that is created by the vagrant command shown above).
 
 ## Additional vagrant deployment options
 While the `vagrant up` command that is shown above can be used to easily deploy Solr to a node, the Vagrantfile included in this distribution also supports separating out the creation of the virtual machine from the provisioning of that virtual machine using the Ansible playbook contained in this repository's `site.yml` file. To create a virtual machine without provisioning it, simply run a command that looks something like this:
@@ -72,12 +84,12 @@ $ vagrant -s="192.168.34.12" provision
 
 That command will attach to the named instance (the VM at "192.168.34.12") and run the playbook in this repository's `site.yml` file on that node (resulting in the deployment of an instance the LucidWorks Fusion distribution of Solr to that node).
 
-It should also be noted here that while the commands shown above will install Solr with a reasonable default configuration from a standard location, there are two additional command-line parameters that can be used to override the default values that are embedded in the `vars/solr.yml` file that is included as part of this repository:  the `-u` (or corresponding `--url`) flag and the `-p` (or corresponding `--path`) flag.  The `-u` flag can be used to override the default URL that is used to download the LucidWorks Fusion (Solr) distribution (which points back to the main LucidWorks distribution site), while the `-p` flag can be used to override the default path (`/opt/fusion`) that that the LucidWorks Fusion gzipped tarfile is unpacked into during the provisioning process.
+It should also be noted here that while the commands shown above will install Solr with a reasonable default configuration from a standard location, there are two additional command-line parameters that can be used to override the default values that are embedded in the `vars/solr.yml` file that is included as part of this repository:  the `-u` (or corresponding `--url`) flag and the `-p` (or corresponding `--path`) flag.  The `-u` flag can be used to override the default URL that is used to download the LucidWorks Fusion (Solr) distribution (which points back to the main LucidWorks distribution site), while the `-p` flag can be used to override the default path (`/opt/lucidworks`) that that the LucidWorks Fusion gzipped tarfile is unpacked into during the provisioning process.
 
 As an example of how these options might be used, the following command will download the gzipped tarfile containing the LucidWorks Fusion distribution from a local web server, rather than downloading it from the main LucidWorks distribution site and unpack the downladed gzipped tarfile into the `/opt/solr` directory when provisioning the VM with an IP address of `192.168.34.12` with an instance of the LucidWorks Fusion distribution:
 
 ```bash
-$ vagrant -k="192.168.34.12" -p="/opt/solr" -u="https://10.0.2.2/fusion-2.4.4.tar.gz" provision
+$ vagrant -k="192.168.34.12" -p="/opt/solr" -u="https://10.0.2.2/fusion-3.0.0.tar.gz" provision
 ```
 
 Obviously, this option could prove to be quite useful in situations were we are deploying the distribution from a datacenter environment (where access to the internet may be restricted, or even unavailable).

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,18 +21,37 @@ class OptionParser
   end
 end
 
+# initialize a few values
 options = {}
+VALID_ZK_ENSEMBLE_SIZES = [3, 5, 7]
+
+# vagrant commands that include these commands can be run without specifying
+# any IP addresses
 no_ip_commands = ['version', 'global-status', '--help', '-h']
+# vagrant commands that only work for a single IP address
+single_ip_commands = ['status', 'ssh']
+# vagrant command arguments that indicate we are provisioning a cluster (if multiple
+# nodes are supplied via the `--solr-list` flag)
+provisioning_command_args = ['up', 'provision']
+no_zk_required_command_args = ['destroy']
+not_provisioning_flag = ['--no-provision']
 
 optparse = OptionParser.new do |opts|
   opts.banner    = "Usage: #{opts.program_name} [options]"
   opts.separator "Options"
 
-  options[:solr_addr] = nil
-  opts.on( '-s', '--solr-addr IP_ADDR', 'IP_ADDR of the solr server' ) do |solr_addr|
+  options[:solr_list] = nil
+  opts.on( '-s', '--solr-list A1,A2[,...]', 'Solr address list (multi-node commands)' ) do |solr_list|
     # while parsing, trim an '=' prefix character off the front of the string if it exists
     # (would occur if the value was passed using an option flag like '-s=192.168.1.1')
-    options[:solr_addr] = solr_addr.gsub(/^=/,'')
+    options[:solr_list] = solr_list.gsub(/^=/,'')
+  end
+
+  options[:zookeeper_list] = nil
+  opts.on( '-z', '--zookeeper-list A1,A2[,...]', 'Zookeeper address list (multi-node commands)' ) do |zookeeper_list|
+    # while parsing, trim an '=' prefix character off the front of the string if it exists
+    # (would occur if the value was passed using an option flag like '-z=192.168.1.1')
+    options[:zookeeper_list] = zookeeper_list.gsub(/^=/,'')
   end
 
   options[:solr_path] = nil
@@ -49,6 +68,20 @@ optparse = OptionParser.new do |opts|
     options[:solr_url] = solr_url.gsub(/^=/,'')
   end
 
+  options[:local_solr_file] = nil
+  opts.on( '-l', '--local-file FILE', 'Local (gzipped tar)file containing Fusion (Solr) distribution' ) do |local_solr_file|
+    # while parsing, trim an '=' prefix character off the front of the string if it exists
+    # (would occur if the value was passed using an option flag like '-l=/tmp/fusion-2.4.4.tar.gz')
+    options[:local_solr_file] = local_solr_file.gsub(/^=/,'')
+  end
+
+  options[:yum_repo_addr] = nil
+  opts.on( '-y', '--yum-repo-host REPO_HOST', 'Local yum repository hostname/address' ) do |yum_repo_addr|
+    # while parsing, trim an '=' prefix character off the front of the string if it exists
+    # (would occur if the value was passed using an option flag like '-y=192.168.1.128')
+    options[:yum_repo_addr] = yum_repo_addr.gsub(/^=/,'')
+  end
+
   opts.on_tail( '-h', '--help', 'Display this screen' ) do
     print opts
     exit
@@ -58,7 +91,7 @@ end
 
 begin
   optparse.order_recognized!(ARGV)
-rescue SystemExit
+rescue SystemExit => e
   exit
 rescue Exception => e
   print "ERROR: could not parse command (#{e.message})\n"
@@ -69,132 +102,203 @@ end
 # check remaining arguments to see if the command requires
 # an IP address (or not)
 ip_required = (ARGV & no_ip_commands).empty?
+# check the remaining arguments to see if we're provisioning or not
+provisioning_command = !((ARGV & provisioning_command_args).empty?) && (ARGV & not_provisioning_flag).empty?
+# and to see if multiple IP addresses are supported (or not) for the
+# command being invoked
+single_ip_command = !((ARGV & single_ip_commands).empty?)
+# and to see if a zookeeper ensemble must also be provided
+no_zk_required_command = !(ARGV & no_zk_required_command_args).empty?
 
-if ip_required && !options[:solr_addr]
-  print "ERROR; server IP address must be supplied for vagrant commands\n"
-  print optparse
-  exit 1
-elsif options[:solr_addr] && !(options[:solr_addr] =~ Resolv::IPv4::Regex)
-  print "ERROR; input server IP address '#{options[:solr_addr]}' is not a valid IP address"
+if options[:solr_url] && !(options[:solr_url] =~ URI::regexp)
+  print "ERROR; input solr URL '#{options[:solr_url]}' is not a valid URL\n"
+  exit 3
+end
+
+if options[:local_solr_file] && !File.file?(options[:local_solr_file])
+  print "ERROR; input local solr file '#{options[:local_solr_file]}' is not a local file\n"
+  exit 3
+end
+
+if options[:solr_url] && options[:local_solr_file]
+  print "ERROR; the solr-url option and the local-solr-file options cannot be combined\n"
   exit 2
 end
 
-if options[:solr_url] && !(options[:solr_url] =~ URI::regexp)
-  print "ERROR; input Solr URL '#{options[:solr_url]}' is not a valid URL\n"
-  exit 3
+# if we're provisioning, then either the `--node` flag should be provided
+# and only contain a single node or the `--solr-list` flag must be provided and
+# contain multiple nodes that define a valid definition for solr cluster that
+# we're provisioning
+solr_addr_array = []
+zookeeper_addr_array = []
+if provisioning_command || ip_required
+  if !options[:solr_list]
+    print "ERROR; IP address must be supplied (using the `-s, --solr-list` flag) for this vagrant command\n"
+    exit 1
+  else
+    solr_addr_array = options[:solr_list].split(',').map { |elem| elem.strip }.reject { |elem| elem.empty? }
+    if solr_addr_array.size == 1
+      if !(solr_addr_array[0] =~ Resolv::IPv4::Regex)
+        print "ERROR; input Solr IP address #{solr_addr_array[0]} is not a valid IP address\n"
+        exit 2
+      end
+    elsif !single_ip_command
+      # check the input `solr_addr_array` to ensure that all of the values passed in are
+      # legal IP addresses
+      not_ip_addr_list = solr_addr_array.select { |addr| !(addr =~ Resolv::IPv4::Regex) }
+      if not_ip_addr_list.size > 0
+        # if some of the values are not valid IP addresses, print an error and exit
+        if not_ip_addr_list.size == 1
+          print "ERROR; input Solr IP address #{not_ip_addr_list} is not a valid IP address\n"
+          exit 2
+        else
+          print "ERROR; input Solr IP addresses #{not_ip_addr_list} are not valid IP addresses\n"
+          exit 2
+        end
+      end
+      # when provisioning a multi-node Solr cluster, we **must** have an associated zookeeper
+      # ensemble consisting of an odd number of nodes greater than three, but less than seven
+      # (any other topology is not supported, so an error is thrown)
+      if solr_addr_array.size > 1 && !no_zk_required_command
+        if !options[:zookeeper_list]
+          print "ERROR; A set of IP addresses must be supplied (using the `-z, --zookeeper-list` flag)\n"
+          print "       that point to an existing Zookeeper ensemble when provisioning a Solr cluster\n"
+          exit 1
+        else
+          zookeeper_addr_array = options[:zookeeper_list].split(',').map { |elem| elem.strip }.reject { |elem| elem.empty? }
+          # check the input `zookeeper_addr_array` to ensure that all of the values passed in are
+          # legal IP addresses
+          not_ip_addr_list = zookeeper_addr_array.select { |addr| !(addr =~ Resolv::IPv4::Regex) }
+          if not_ip_addr_list.size > 0
+            # if some of the values are not valid IP addresses, print an error and exit
+            if not_ip_addr_list.size == 1
+              print "ERROR; input Solr IP address #{not_ip_addr_list} is not a valid IP address\n"
+              exit 2
+            else
+              print "ERROR; input Solr IP addresses #{not_ip_addr_list} are not valid IP addresses\n"
+              exit 2
+            end
+          end
+          # and check to make sure that an appropriate number of zookeeper addresses were
+          # passed in (the size of the ensemble should be an odd number between three and seven)
+          if !(VALID_ZK_ENSEMBLE_SIZES.include?(zookeeper_addr_array.size))
+            print "ERROR; only a zookeeper cluster with an odd number of elements between three and\n"
+            print "       seven is supported for multi-node solr deployments; the defined cluster\n"
+            print "       #{zookeeper_addr_array} contains #{zookeeper_addr_array.size} elements\n"
+            exit 5
+          end
+          # finally, we need to make sure that the machines we're deploying solr to are not the same
+          # machines that make up our zookeeper ensemble (the zookeeper ensemble must be on a separate
+          # set of machines from the solr cluster)
+          same_addr_list = zookeeper_addr_array & solr_addr_array
+          if same_addr_list.size > 0
+            print "ERROR; the solr cluster cannot be deployed to the same machines that make up\n"
+            print "       the zookeeper ensemble; requested clusters overlap for the machines at\n"
+            print "       #{same_addr_list}\n"
+            exit 7
+          end
+        end
+      end
+    end
+  end
+end
+
+# if a yum repository address was passed in, check and make sure it's a valid
+# IPv4 address
+if options[:yum_repo_addr] && !(options[:yum_repo_addr] =~ Resolv::IPv4::Regex)
+  print "ERROR; input yum repository address '#{options[:yum_repo_addr]}' is not a valid IP address\n"
+  exit 6
 end
 
 # All Vagrant configuration is done below. The "2" in Vagrant.configure
 # configures the configuration version (we support older styles for
 # backwards compatibility). Please don't change it unless you know what
 # you're doing.
-proxy = ENV['http_proxy'] || ""
-no_proxy = ENV['no_proxy'] || ""
-proxy_username = ENV['proxy_username'] || ""
-proxy_password = ENV['proxy_password'] || ""
-Vagrant.configure("2") do |config|
-  if Vagrant.has_plugin?("vagrant-proxyconf")
-    if $proxy
-      config.proxy.http               = $proxy
-      config.proxy.no_proxy           = "localhost,127.0.0.1"
-      config.vm.box_download_insecure = true
-      config.vm.box_check_update      = false
+if solr_addr_array.size > 0
+  Vagrant.configure("2") do |config|
+    proxy = ENV['http_proxy'] || ""
+    no_proxy = ENV['no_proxy'] || ""
+    proxy_username = ENV['proxy_username'] || ""
+    proxy_password = ENV['proxy_password'] || ""
+    if Vagrant.has_plugin?("vagrant-proxyconf")
+      if $proxy
+        config.proxy.http               = $proxy
+        config.vm.box_download_insecure = true
+        config.vm.box_check_update      = false
+      end
+      if $no_proxy
+        config.proxy.no_proxy           = $no_proxy
+      end
+      if $proxy_username
+        config.proxy.proxy_username     = $proxy_username
+      end
+      if $proxy_password
+        config.proxy.proxy_password     = $proxy_password
+      end
     end
-    if $no_proxy
-      config.proxy.no_proxy           = $no_proxy
-    end
-    if $proxy_username
-      config.proxy.proxy_username     = $proxy_username
-    end
-    if $proxy_password
-      config.proxy.proxy_password     = $proxy_password
-    end
-  end
-  # The most common configuration options are documented and commented below.
-  # For a complete reference, please see the online documentation at
-  # https://docs.vagrantup.com.
 
-  # Every Vagrant development environment requires a box. You can search for
-  # boxes at https://atlas.hashicorp.com/search.
-  config.vm.box = "centos/7"
+    # Every Vagrant development environment requires a box. You can search for
+    # boxes at https://atlas.hashicorp.com/search.
+    config.vm.box = "centos/7"
+    config.vm.box_check_update = false
 
-  # Disable automatic box update checking. If you disable this, then
-  # boxes will only be checked for updates when the user runs
-  # `vagrant box outdated`. This is not recommended.
-  # config.vm.box_check_update = false
+    # loop through all of the addresses in the `solr_addr_array` and, if we're
+    # creating VMs, create a VM for each machine; if we're just provisioning the
+    # VMs using an ansible playbook, then wait until the last VM in the loop and
+    # trigger the playbook runs for all of the nodes simultaneously using the
+    # `site.yml` playbook
+    solr_addr_array.each do |machine_addr|
+      # Customize the amount of memory on the VM
+      config.vm.provider "virtualbox" do |vb|
+        vb.memory = "4096"
+      end
+      config.vm.define machine_addr do |machine|
+        # setup a private network for this machine
+        machine.vm.network "private_network", ip: machine_addr
 
-  # Create a forwarded port mapping which allows access to a specific port
-  # within the machine from a port on the host machine. In the example below,
-  # accessing "localhost:8080" will access port 80 on the guest machine.
-  # config.vm.network "forwarded_port", guest: 80, host: 8080
-
-  # Create a private network, which allows host-only access to the machine
-  # using a specific IP.
-  config.vm.network "private_network", ip: "#{options[:solr_addr]}"
-
-  # Create a public network, which generally matched to bridged network.
-  # Bridged networks make the machine appear as another physical device on
-  # your network.
-  # config.vm.network "public_network"
-
-  # Share an additional folder to the guest VM. The first argument is
-  # the path on the host to the actual folder. The second argument is
-  # the path on the guest to mount the folder. And the optional third
-  # argument is a set of non-required options.
-  # config.vm.synced_folder "../data", "/vagrant_data"
-  config.vm.synced_folder ".", "/vagrant"
-
-  # Provider-specific configuration so you can fine-tune various
-  # backing providers for Vagrant. These expose provider-specific options.
-  # Example for VirtualBox:
-  #
-  # config.vm.provider "virtualbox" do |vb|
-  #   # Display the VirtualBox GUI when booting the machine
-  #   vb.gui = true
-  #
-  #   # Customize the amount of memory on the VM:
-  #   vb.memory = "1024"
-  # end
-  #
-  # View the documentation for the provider you are using for more
-  # information on available options.
-
-  config.vm.provider "virtualbox" do |vb|
-    # Customize the amount of memory on the VM:
-    vb.memory = "8192"
-  end
-
-  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
-  # such as FTP and Heroku are also available. See the documentation at
-  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
-  # config.push.define "atlas" do |push|
-  #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
-  # end
-
-  config.vm.define "#{options[:solr_addr]}"
-  solr_addr_array = "#{options[:solr_addr]}".split(/,\w*/)
-
-  config.vm.provision "ansible" do |ansible|
-    ansible.playbook = "site.yml"
-    ansible.extra_vars = {
-      proxy_env: {
-        http_proxy: proxy,
-        no_proxy: no_proxy,
-        proxy_username: proxy_username,
-        proxy_password: proxy_password
-      },
-      host_inventory: solr_addr_array
-    }
-    # if defined, set the 'extra_vars[:solr_url]' value to the value that was passed in on
-    # the command-line (eg. "https://10.0.2.2/fusion-2.4.4.tar.gz")
-    if options[:solr_url]
-      ansible.extra_vars[:solr_url] = "#{options[:solr_url]}"
-    end
-    # if defined, set the 'extra_vars[:solr_path]' value to the value that was passed in on
-    # the command-line (eg. "/opt/fusion")
-    if options[:solr_path]
-      ansible.extra_vars[:solr_path] = "#{options[:solr_path]}"
-    end
-  end
-
-end
+        # if it's the last node in the list if input addresses, then provision
+        # all of the nodes simultaneously (if the `--no-provision` flag was not
+        # set, of course)
+        if machine_addr == solr_addr_array[-1]
+          # now, use the playbook in the `site.yml' file to provision our
+          # nodes with Solr (and configure them as a cluster if there
+          # is more than one node)
+          machine.vm.provision "ansible" do |ansible|
+            # set the limit to 'all' in order to provision all of machines on the
+            # list in a single playbook run
+            ansible.limit = "all"
+            ansible.playbook = "site.yml"
+            ansible.extra_vars = {
+              proxy_env: {
+                http_proxy: proxy,
+                no_proxy: no_proxy,
+                proxy_username: proxy_username,
+                proxy_password: proxy_password
+              },
+              solr_iface: "eth1",
+              yum_repo_addr: options[:yum_repo_addr],
+              local_solr_file: options[:local_solr_file],
+              host_inventory: solr_addr_array
+            }
+            # if defined, set the 'extra_vars[:solr_url]' value to the value that was passed in on
+            # the command-line (eg. "https://10.0.2.2/fusion-2.4.4.tar.gz")
+            if options[:solr_url]
+              ansible.extra_vars[:solr_url] = options[:solr_url]
+            end
+            # if defined, set the 'extra_vars[:solr_dir]' value to the value that was passed in on
+            # the command-line (eg. "/opt/solr")
+            if options[:solr_path]
+              ansible.extra_vars[:solr_dir] = options[:solr_path]
+            end
+            # if a zookeeper list was passed in and we're deploying more than one Solr,
+            # node, then pass the values in that list through as an extra variable (for
+            # use in configuring the SolrCloud cluster that we're deploying)
+            if zookeeper_addr_array.size > 1 && solr_addr_array.size > 1
+              ansible.extra_vars[:zookeeper_nodes] = zookeeper_addr_array
+            end
+          end     # end `machine.vm.provision "ansible" do |ansible|`
+        end     # end `if machine_addr == solr_addr_array[-1]`
+      end     # end `config.vm.define machine_addr do |machine|`
+    end     # end `solr_addr_array.each do |machine_addr|`
+  end     # end `Vagrant.configure ("2") do |config|`
+end     # end `if solr_addr_array.size > 0`

--- a/site.yml
+++ b/site.yml
@@ -7,7 +7,14 @@
   vars:
     - combined_package_list: "{{ (default_packages|default([])) | union(solr_package_list) | union((install_packages_by_tag|default({})).solr|default([])) }}"
   roles:
-    - ensure-interfaces-up
-    - setup-web-proxy
-    - { role: install-packages, package_list: "{{combined_package_list}}" }
-    - dn-solr
+    - role: ensure-interfaces-up
+    - role: get-iface-addr
+      iface_name: "{{solr_iface}}"
+    - role: setup-web-proxy
+    - role: add-local-repository
+      yum_repository: "{{yum_repo_addr}}"
+      when: yum_repo_addr is defined
+    - role: install-packages
+      package_list: "{{combined_package_list}}"
+    - role: dn-solr
+      solr_addr: "{{iface_addr}}"

--- a/tasks/add-solr-user.yml
+++ b/tasks/add-solr-user.yml
@@ -1,15 +1,14 @@
 # (c) 2016 DataNexus Inc.  All Rights Reserved
 ---
-- name: Create solr group
+- block:
+  - name: Create lucidworks group
+    group:
+      name: lucidworks
+      system: yes
+  - name: Create lucidworks user
+    user:
+      name: lucidworks
+      group: lucidworks
+      createhome: no
+      system: yes
   become: true
-  group:
-    name: solr
-    system: yes
-- name: Create solr user
-  become: true
-  user:
-    name: solr
-    group: solr
-    createhome: no
-    system: yes
-    

--- a/tasks/create-solr-services.yml
+++ b/tasks/create-solr-services.yml
@@ -1,9 +1,8 @@
 # (c) 2016 DataNexus Inc.  All Rights Reserved
 ---
-- name: Create solr service files
+- block:
+  - name: Run the install script
+    command: "{{full_solr_dir}}/init/systemd/install.sh"
+  - name: Restart the systemctl daemon
+    command: systemctl daemon-reload
   become: true
-  command: "{{solr_dir}}/init/systemd/install.sh"
-- name: restart systemctl daemon
-  become: true
-  command: systemctl daemon-reload
-  

--- a/tasks/enable-solr-services.yml
+++ b/tasks/enable-solr-services.yml
@@ -1,14 +1,5 @@
 # (c) 2016 DataNexus Inc.  All Rights Reserved
 ---
-- name: Enable solr services on boot
+- name: Enable fusion services on boot
   become: true
-  command: "systemctl enable {{item}}"
-  with_items:
-    - fusion-zookeeper.service
-    - fusion-solr.service
-    - fusion-spark-master.service
-    - fusion-spark-worker.service
-    - fusion-api.service
-    - fusion-connectors.service
-    - fusion-ui.service
-  
+  command: systemctl enable fusion

--- a/tasks/install-lucidworks-fusion.yml
+++ b/tasks/install-lucidworks-fusion.yml
@@ -1,26 +1,49 @@
 # (c) 2016 DataNexus Inc.  All Rights Reserved
-- name: Download solr distribution to /tmp
+---
+# First, setup a couple a fact so that can test whether or not we're
+# installing Fusion from a local directory on the Ansible node (or not)
+- set_fact:
+    install_from_dir: "{{not(local_solr_file is undefined or local_solr_file is none or local_solr_file | trim == '')}}"
+# if we're not installing fusion from a local directory then we're installing
+# from a repository (either a local repository or the standard LucidWorks Fusion
+# repository)
+- block:
+  - name: Download solr distribution to /tmp
+    become: true
+    get_url:
+      url: "{{solr_url}}"
+      dest: /tmp
+      mode: 0644
+      validate_certs: no
+    environment: "{{environment_vars}}"
+  - set_fact:
+      local_filename: "{{solr_url | basename}}"
+  when: not(install_from_dir)
+# otherwise, if we're installing from a local directory on the Ansible node
+# that we're running this playbook from, copy over the files from that directory
+# to a temporary directory and and install the Confluent packages from those files
+- block:
+  - name: Copy confluent files from a local directory to /tmp
+    copy:
+      src: "{{local_solr_file}}"
+      dest: "/tmp"
+  - set_fact:
+      local_filename: "{{local_solr_file | basename}}"
+  when: install_from_dir
+# finally, create a directory and unpack the distribution we downloaded into
+# that directory
+- block:
+  - name: Create "{{solr_dir}}"
+    file:
+      path: "{{solr_dir}}"
+      state: directory
+      owner: lucidworks
+      group: lucidworks
+  - name: Unpack solr distribution into "{{solr_dir}}"
+    unarchive:
+      copy: no
+      src: "/tmp/{{local_filename}}"
+      dest: "{{solr_dir}}"
+      owner: lucidworks
+      group: lucidworks
   become: true
-  get_url:
-    url: "{{solr_url}}"
-    dest: /tmp
-    mode: 0644
-    validate_certs: no
-  environment: "{{environment_vars}}"
-- name: Create "{{solr_dir}}"
-  become: true
-  file:
-    path: "{{solr_dir}}"
-    state: directory
-    owner: solr
-    group: solr
-- name: Unpack solr distribution into "{{solr_dir}}"
-  become: true
-  unarchive:
-    copy: no
-    src: "/tmp/fusion-2.4.4.tar.gz"
-    dest: "{{solr_dir}}"
-    extra_opts: [ "--strip-components=1" ]
-    owner: solr
-    group: solr
-    

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,8 @@
 # (c) 2016 DataNexus Inc.  All Rights Reserved
-- include: add-solr-user.yml static=no tags=install,solr
-- include: install-lucidworks-fusion.yml static=no tags=install,solr
-- include: create-solr-services.yml static=no tags=install,solr
-- include: enable-solr-services.yml static=no tags=service-mgmt,solr
-- include: start-solr-services.yml static=no tags=service-mgmt,solr
+---
+- include: add-solr-user.yml static=no
+- include: install-lucidworks-fusion.yml static=no
+- include: setup-solr-server-properties.yml static=no
+- include: create-solr-services.yml static=no
+- include: enable-solr-services.yml static=no
+- include: start-solr-services.yml static=no

--- a/tasks/setup-solr-server-properties.yml
+++ b/tasks/setup-solr-server-properties.yml
@@ -1,0 +1,58 @@
+# (c) 2016 DataNexus Inc.  All Rights Reserved
+---
+# configure our Solr instance to point to the Zookeeper cluster
+# (if one is defined, of course)
+- block:
+  - name: Find install directory name
+    find:
+      file_type: directory
+      path: "{{solr_dir}}"
+      recurse: yes
+      patterns: apps
+    register: find_results
+  - set_fact: full_solr_dir="{{find_results.files.0.path | dirname}}"
+# if we're setting up a Fusion cluster, then change the configuration
+# file accordingly (setting the Zookeeper-related parameters to point
+# to the IP addresses of the Zookeeper cluster that was passed in and
+# setting up the fusion.properties file so that Zookeeper will not
+# be started up locally)
+- block:
+  - name: Setup references to zookeeper cluster in conf/fusion.properties
+    lineinfile:
+      dest: "{{full_solr_dir}}/conf/fusion.properties"
+      regexp: "^FUSION_ZK="
+      line: "FUSION_ZK={{(zookeeper_nodes | default([])) | join(':2181,')}}:2181"
+  - name: Set local address to address of NIC that Solr should listen on
+    lineinfile:
+      dest: "{{full_solr_dir}}/conf/fusion.properties"
+      regexp: "^(#)?default.address ="
+      line: "default.address = {{iface_addr}}"
+  - name: Define ZK Connect address for Solr
+    lineinfile:
+      dest: "{{full_solr_dir}}/conf/fusion.properties"
+      regexp: "^(# )?default.zk.connect ="
+      line: "default.zk.connect = {{(zookeeper_nodes | default([])) | join(':2181,')}}:2181"
+  - name: Disable startup of local Zookeeper instance
+    replace:
+      dest: "{{full_solr_dir}}/conf/fusion.properties"
+      regexp: '^(.*)zookeeper, (.*)$'
+      replace: '\g<1>\g<2>'
+  become: true
+  when: (zookeeper_nodes | default([])) != []
+# If this is a single-node deployment, then we'll also be starting up the
+# built-in Zookeeper instance that comes with Fusion; in that case, configure
+# that Zookeeper instance to use the data directory that was passed in
+- block:
+  - name: "Ensure {{solr_data_dir}} directory exists"
+    file:
+      path: "{{solr_data_dir}}/zookeeper"
+      state: directory
+      owner: lucidworks
+      group: lucidworks
+  - name: And ensure that Zookeeper is configured to use that data directory
+    lineinfile:
+      dest: "{{full_solr_dir}}/conf/zookeeper/zoo.cfg"
+      regexp: "^dataDir="
+      line: "dataDir={{solr_data_dir}}/zookeeper"
+  become: true
+  when: (zookeeper_nodes | default([])) == []

--- a/tasks/start-solr-services.yml
+++ b/tasks/start-solr-services.yml
@@ -1,5 +1,5 @@
 # (c) 2016 DataNexus Inc.  All Rights Reserved
 ---
-- name: Start solr services
+- name: Start fusion service
+  command: systemctl start fusion
   become: true
-  command: "{{solr_dir}}/init/systemd/start.sh"

--- a/vars/solr.yml
+++ b/vars/solr.yml
@@ -4,6 +4,24 @@
 # LucidWorks Fusion (Solr)
 ---
 application: solr
-solr_url: "https://download.lucidworks.com/fusion-2.4.4.tar.gz"
-solr_dir: "/opt/fusion"
+
+# the URL that should be used to download the Fusion (Solr) distribution
+# (Fusion is distributed as a gzipped tarfile)
+solr_url: "https://download.lucidworks.com/fusion-3.0.0.tar.gz"
+
+# the directory where the solr data will be written
+solr_data_dir: /opt/lucidworks/data
+
+# the interface Fusion (Solr) should listen on when running
+solr_iface: eth0
+
+# the directory that the distribution should be unpacked into
+solr_dir: "/opt/lucidworks"
+
+# the packages that need to be installed for Solr nodes (the JRE and JDK
+# packages from the OpenJDK project)
 solr_package_list: ["java-1.8.0-openjdk", "java-1.8.0-openjdk-devel"]
+
+# used to install Fusion (Solr) from a local (to the Ansible node) gzipped
+# tarfile (if it exists)
+local_solr_file: ""


### PR DESCRIPTION
The changes in this PR add the ability to deploy multi-node Fusion (Solr) clusters.  The latest LucidWorks Fusion package is installed and configured such that built-in Zookeeper instances that are started up when the fusion service starts (along with the solr, API, UI, connector, and agent services) are all configured as an ensemble.  There is still work to be done, but this should provide us with the ability to deploy a production Solr cluster using the LucidWorks Fusion distribution.

Specifically:

* The Vagrantfile has been changed to support deployment of LucidWorks Fusion to more than one node (or to a single node) using the `--solr-list` (or `--node`) flag
* Ansible tags have been introduced to the `dn-solr` role and its tasks to support the future capability to deploy the Zookeeper ensemble onto a separate set of nodes from those used for the Fusion cluster, but that separation has not been completely implemented yet (it was felt that for our immediate needs, support for a cluster where the Zookeeper ensemble and Fusion cluster are co-located on the same machines was sufficient).  The additional changes should not be too difficult (primarily involving which services are started when the fusion service is started; something we should easily be able to fix by modifying a single line in the `fusion.properties` file) but we've left those changes as work for the future (when the need for a separate Zookeeper ensemble arises)
* The tasks in this role were modified to support the configuration that was needed for the latest version of the LucidWorks Fusion distribution (v3.x); with the change from Fusion 2.x to Fusion 3.x (they changed over to a Solr 6.x release in the Fusion 3.x release), the process of configuring the underlying cluster changed significantly.  The tasks in this role will only support Fusion v3.x and later, and no attempt has been made to make them backwards compatible to the Fusion 2.x release.
* The `vars/solr.yml` file has been modified to include some of the new capabilities that were added in this PR.

As was mentioned previously, there are a few outstanding issues not addressed by this PR.  Specifically:

* While a parameter was added to give the user the ability to specify the data directory that should be used by the Fusion services, that parameter is only currently used to set the data directory used by the Zookeeper cluster; the underlying SolrCloud instances maintain their collections (by default) in a `data` directory within the directory tree that the distribution unpacked into.  Obviously we would like to resolve this issue as soon as possible, but for now the collections can be placed in a directory with more capacity by simply unpacking the Fusion distribution into that directory.  In addition, the ability to specify this parameter does not currently exist in the command-line flags for the Vagrantfile, but that can be easily rectified later (when we sort out how to modify the default directory used for collections by Solr)
* We currently do not support the ability to deploy a Zookeeper cluster separate from the Solr cluster.  Realistically this limits our Solr cluster to an odd number of nodes between 3 and 7.  As was mentioned previously, it's relatively simple to modify the existing Ansible role and Vagrantfile to support this capability if this restriction on the number of SolrCloud nodes in our Fusion cluster becomes a problem, but for now we've left that as an issue that we will resolve in the not-too-distant future.