### PR TITLE
Adds support for a user-defined data directory

### DIFF
--- a/tasks/install-lucidworks-fusion.yml
+++ b/tasks/install-lucidworks-fusion.yml
@@ -1,7 +1,7 @@
 # (c) 2016 DataNexus Inc.  All Rights Reserved
 ---
-# First, setup a couple a fact so that can test whether or not we're
-# installing Fusion from a local directory on the Ansible node (or not)
+# First, setup a fact so that can test whether or not we're installing
+# Fusion from a local directory on the Ansible node
 - set_fact:
     install_from_dir: "{{not(local_solr_file is undefined or local_solr_file is none or local_solr_file | trim == '')}}"
 # if we're not installing fusion from a local directory then we're installing
@@ -23,7 +23,7 @@
 # that we're running this playbook from, copy over the files from that directory
 # to a temporary directory and and install the Confluent packages from those files
 - block:
-  - name: Copy confluent files from a local directory to /tmp
+  - name: Copy fusion distribution from a local directory to /tmp
     copy:
       src: "{{local_solr_file}}"
       dest: "/tmp"

--- a/tasks/move-files.yml
+++ b/tasks/move-files.yml
@@ -1,0 +1,11 @@
+# (c) 2016 DataNexus Inc.  All Rights Reserved
+---
+- block:
+  - name: "stat {{solr_data_dir}}/{{item | basename}}"
+    stat:
+      path: "{{solr_data_dir}}/{{item | basename}}"
+    register: item_stat
+  - name: "Move item if does not exist in {{solr_data_dir}}"
+    command: "mv {{item}} {{solr_data_dir}}/{{item | basename}}"
+    when: not (item_stat.stat.exists)
+  become: true

--- a/tasks/setup-solr-server-properties.yml
+++ b/tasks/setup-solr-server-properties.yml
@@ -39,16 +39,62 @@
       replace: '\g<1>\g<2>'
   become: true
   when: (zookeeper_nodes | default([])) != []
+# setup the garbage collection option we want to use
+- name: Change garbage algorithm used to the 'g1' algorithm
+  lineinfile:
+    dest: "{{full_solr_dir}}/conf/fusion.properties"
+    regexp: "^default.gc ="
+    line: "default.gc = g1"
+  become: true
+# if a `solr_data_dir` value was passed in, then ensure that directory
+# exists, move the contents of the default directory over to that
+# `solr_data_dir` directory, remove the default data directory, and replace
+# it with a soft link to the new `solr_data_dir` directory
+- block:
+  - name: "Ensure {{solr_data_dir}} directory exists"
+    file:
+      path: "{{solr_data_dir}}"
+      state: directory
+      owner: lucidworks
+      group: lucidworks
+  - name: "Get a list of the contents to copy over to the {solr_data_dir}} directory"
+    find:
+      paths: "{{full_solr_dir}}/data"
+      file_type: file
+    register: file_list
+  - find:
+      paths: "{{full_solr_dir}}/data"
+      file_type: directory
+    register: dir_list
+  become: true
+  when: not (solr_data_dir is undefined or solr_data_dir is none or solr_data_dir | trim == '')
+# loop through the items in our list and, if they don't exist in the new
+# data directory, move them over there
+- include: move-files.yml
+  with_items: "{{(dir_list.files + file_list.files) | map(attribute='path') | list}}"
+  when: not (solr_data_dir is undefined or solr_data_dir is none or solr_data_dir | trim == '')
+# and finally, now that the contents are moved, remove the default
+# data directory and replace it with a soft link
+- block:
+  - name: "Ensure {{full_solr_dir}}/data directory is removed"
+    file:
+      path: "{{full_solr_dir}}/data"
+      state: absent
+      owner: lucidworks
+      group: lucidworks
+  - name: "Setup {{full_solr_dir}}/data as a softlink to {{solr_data_dir}}"
+    file:
+      src: "{{solr_data_dir}}"
+      dest: "{{full_solr_dir}}/data"
+      state: link
+      owner: lucidworks
+      group: lucidworks
+  become: true
+  when: not (solr_data_dir is undefined or solr_data_dir is none or solr_data_dir | trim == '')
 # If this is a single-node deployment, then we'll also be starting up the
 # built-in Zookeeper instance that comes with Fusion; in that case, configure
 # that Zookeeper instance to use the data directory that was passed in
 - block:
-  - name: "Ensure {{solr_data_dir}} directory exists"
-    file:
-      path: "{{solr_data_dir}}/zookeeper"
-      state: directory
-      owner: lucidworks
-      group: lucidworks
   - name: And ensure that Zookeeper is configured to use that data directory
     lineinfile:
       dest: "{{full_solr_dir}}/conf/zookeeper/zoo.cfg"


### PR DESCRIPTION
The changes in this PR add support for setting up a data directory to use instead of the default directory used by Fusion.  Since the LucidWorks Fusion team hasn't seen fit to provide us with easy access to a parameter that we can use to set the data directory that should be used by Fusion and it's services, we are accomplishing this by moving any files/directories from the default data directory that is used by Fusion (`${FUSION_HOME}/data`) to whatever directory the user has specified as part of the Ansible playbook run (using the `solr_data_dir` variable), then removing the default data directory from the `${FUSION_HOME}` directory and setting up a soft-link to replace that directory.  In doing so, we set up Fusion to use the user-defined data directory without really knowing about it :)

In addition, changes have been made in this PR to clean up some comments and and provide for setting of a few additional configuration parameter definitions in the `fusion.properties` file that were suggested by the team at TLP