### PR TITLE
Changes made during pre-production (OpenStack) testing

### DIFF
--- a/tasks/add-solr-user.yml
+++ b/tasks/add-solr-user.yml
@@ -1,14 +1,14 @@
 # (c) 2016 DataNexus Inc.  All Rights Reserved
 ---
 - block:
-  - name: Create lucidworks group
+  - name: "Create {{solr_group}} group"
     group:
-      name: lucidworks
+      name: "{{solr_group}}"
       system: yes
-  - name: Create lucidworks user
+  - name: "Create {{solr_user}} user"
     user:
-      name: lucidworks
-      group: lucidworks
+      name: "{{solr_user}}"
+      group: "{{solr_group}}"
       createhome: no
       system: yes
   become: true

--- a/tasks/create-solr-services.yml
+++ b/tasks/create-solr-services.yml
@@ -1,8 +1,19 @@
 # (c) 2016 DataNexus Inc.  All Rights Reserved
 ---
 - block:
+  - name: Modify the install script to comment-out service enablement/startup
+    replace:
+      dest: "{{full_solr_dir}}/init/systemd/install.sh"
+      regexp: "{{item}}"
+      replace: '\g<1>#\g<2>'
+    with_items:
+      - "^(.*)(systemctl enable.*)$"
+      - "^(.*)(systemctl start.*)$"
+      - "^(.*)(systemctl status.*)$"
   - name: Run the install script
     command: "{{full_solr_dir}}/init/systemd/install.sh"
+  - name: Modify permissions on the fusion distribution directory
+    command: "chown -R {{solr_user}}:{{solr_group}} {{solr_dir}}"
   - name: Restart the systemctl daemon
     command: systemctl daemon-reload
   become: true

--- a/tasks/install-lucidworks-fusion.yml
+++ b/tasks/install-lucidworks-fusion.yml
@@ -37,13 +37,13 @@
     file:
       path: "{{solr_dir}}"
       state: directory
-      owner: lucidworks
-      group: lucidworks
+      owner: "{{solr_user}}"
+      group: "{{solr_group}}"
   - name: Unpack solr distribution into "{{solr_dir}}"
     unarchive:
       copy: no
       src: "/tmp/{{local_filename}}"
       dest: "{{solr_dir}}"
-      owner: lucidworks
-      group: lucidworks
+      owner: "{{solr_user}}"
+      group: "{{solr_group}}"
   become: true

--- a/tasks/setup-solr-server-properties.yml
+++ b/tasks/setup-solr-server-properties.yml
@@ -10,6 +10,7 @@
       recurse: yes
       patterns: apps
     register: find_results
+    become: true
   - set_fact: full_solr_dir="{{find_results.files.0.path | dirname}}"
 # if we're setting up a Fusion cluster, then change the configuration
 # file accordingly (setting the Zookeeper-related parameters to point
@@ -55,8 +56,8 @@
     file:
       path: "{{solr_data_dir}}"
       state: directory
-      owner: lucidworks
-      group: lucidworks
+      owner: "{{solr_user}}"
+      group: "{{solr_group}}"
   - name: "Get a list of the contents to copy over to the {solr_data_dir}} directory"
     find:
       paths: "{{full_solr_dir}}/data"
@@ -80,15 +81,15 @@
     file:
       path: "{{full_solr_dir}}/data"
       state: absent
-      owner: lucidworks
-      group: lucidworks
+      owner: "{{solr_user}}"
+      group: "{{solr_group}}"
   - name: "Setup {{full_solr_dir}}/data as a softlink to {{solr_data_dir}}"
     file:
       src: "{{solr_data_dir}}"
       dest: "{{full_solr_dir}}/data"
       state: link
-      owner: lucidworks
-      group: lucidworks
+      owner: "{{solr_user}}"
+      group: "{{solr_group}}"
   become: true
   when: not (solr_data_dir is undefined or solr_data_dir is none or solr_data_dir | trim == '')
 # If this is a single-node deployment, then we'll also be starting up the

--- a/templates/apache-solr.j2
+++ b/templates/apache-solr.j2
@@ -6,8 +6,8 @@ After=network.target remote-fs.target
 
 [Service]
 Type=simple
-User=solr
-Group=solr
+User={{solr_user}}
+Group={{solr_group}}
 Environment='JAVA_OPTS=-Xms1024m -Xmx2048m -XX:MaxPermSize=256m'
 ExecStart={{solr_dir}}/bin/fusion start
 ExecStop={{solr_dir}}/bin/fusion stop

--- a/vars/solr.yml
+++ b/vars/solr.yml
@@ -18,6 +18,11 @@ solr_iface: eth0
 # the directory that the distribution should be unpacked into
 solr_dir: "/opt/lucidworks"
 
+# the username and group that should be used when installing
+# and running Fusion (Solr)
+solr_user: "lucidworks"
+solr_group: "lucidworks"
+
 # the packages that need to be installed for Solr nodes (the JRE and JDK
 # packages from the OpenJDK project)
 solr_package_list: ["java-1.8.0-openjdk", "java-1.8.0-openjdk-devel"]


### PR DESCRIPTION
Made a few last changes in preparation for deployment to production, based on testing that we recently performed by deploying a Fusion cluster to a set of 3 nodes running in the pre-production (OpenStack) environment.  Specifically, we:

* Modified the tasks in our playbook to take the username and group to use when installing and running Fusion from a newly defined pair of parameters (`solr_user` and `solr_group`, respectively) and added a new pair of default values (both are set to `lucidworks` by default) to the defaults defined in the `vars/solr.yml` file
* Added tasks to the playbook to ensure that the install script, when executed, does not attempt to enable the `fusion` service at boot, start up the service or check its status; these tasks are handled separately in the playbook and attempting to execute them as part of the install shell script was leading to failures in the playbook run, since the script needs to run as the `root` user but the service starts up as the `solr_user` user.  The issue, in short, was that the soft links created by the install script were still owned by root, so the `solr_user` user could not access the binaries or configuration files through those soft links.
* Added a task to change the ownership of the soft-links created by the install shell script so that the `fusion` service could be successfully started from the `solr_user` (`lucidworks` by default).

With these changes, we were able to successfully deploy, configure, and start a Fusion cluster in the pre-production environment with that Fusion cluster configured to work with an external Zookeeper ensemble that was started separately (using the `dn-zookeeper` role)