### PR TITLE
Adds support for use of dynamic inventory scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vagrant
+*.pem

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "common-roles"]
 	path = common-roles
 	url = https://github.com/Datanexus/common-roles
+[submodule "common-utils"]
+	path = common-utils
+	url = https://github.com/Datanexus/common-utils

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,3 +1,5 @@
 # (c) 2016 DataNexus Inc.  All Rights Reserved
 [defaults]
 roles_path = ../:common-roles
+#stdout_callback = json
+host_key_checking = False

--- a/site.yml
+++ b/site.yml
@@ -1,13 +1,162 @@
 # (c) 2016 DataNexus Inc.  All Rights Reserved
 ---
-- name: Install/configure solr server
+# If we're running this command for to build a cluster in an AWS or
+# OpenStack cloud, then use the `ec2` or `openstack` command to (depending
+# on the `cloud` we're deploying to) gather the dynamic inventory information
+# that we need to build our Zookeeper host group (and build it)
+- name: Create Zookeeper host group from AWS or OpenStack inventory
   hosts: "{{host_inventory}}"
+  gather_facts: no
+  tasks:
+    # run these commands to add the zookeeper host group for an aws cloud
+    - block:
+      - name: Run ec2 command to gather inventory information
+        local_action: "shell common-utils/inventory/aws/ec2"
+        register: di_output
+      - set_fact:
+          di_output_json: "{{di_output.stdout | from_json}}"
+      - set_fact:
+          cloud_nodes: "{{di_output_json | json_query('tag_Cloud_' + cloud)}}"
+          tenant_nodes: "{{di_output_json | json_query('tag_Tenant_' + tenant)}}"
+          project_nodes: "{{di_output_json | json_query('tag_Project_' + project)}}"
+          domain_nodes: "{{di_output_json | json_query('tag_Domain_' + domain)}}"
+          application_nodes: "{{di_output_json | json_query('tag_Application_zookeeper')}}"
+      - set_fact:
+          zookeeper_nodes: "{{cloud_nodes | intersect(tenant_nodes) | intersect(project_nodes) | intersect(domain_nodes) | intersect(application_nodes)}}"
+      - add_host:
+          name: "{{item}}"
+          groups: "zookeeper"
+          ansible_ssh_user: "{{ansible_user}}"
+          ansible_ssh_private_key_file: "{{private_key_path}}/{{cloud}}-{{di_output_json | json_query('_meta.hostvars.\"' + item + '\".ec2_key_name')}}-private-key.pem"
+        with_items: "{{zookeeper_nodes}}"
+      when: not (inventory_type is undefined or inventory_type == "static") and cloud == "aws"
+      run_once: true
+    # or run these commands to add the zookeeper host group for an osp cloud
+    - block:
+      - name: Run openstack command to gather inventory information
+        local_action: "shell common-utils/inventory/osp/openstack"
+        register: di_output
+      - set_fact:
+          di_output_json: "{{di_output.stdout | from_json}}"
+      - set_fact:
+          cloud_nodes: "{{(di_output_json | json_query('[\"meta-Cloud_' + cloud + '\"]')).0}}"
+          tenant_nodes: "{{(di_output_json | json_query('[\"meta-Tenant_' + tenant + '\"]')).0}}"
+          project_nodes: "{{(di_output_json | json_query('[\"meta-Project_' + project + '\"]')).0}}"
+          domain_nodes: "{{(di_output_json | json_query('[\"meta-Domain_' + domain + '\"]')).0}}"
+          application_nodes: "{{(di_output_json | json_query('[\"meta-Application_zookeeper\"]')).0}}"
+      - set_fact:
+          zookeeper_nodes: "{{cloud_nodes | intersect(tenant_nodes) | intersect(project_nodes) | intersect(domain_nodes) | intersect(application_nodes)}}"
+      - add_host:
+          name: "{{item}}"
+          groups: "zookeeper"
+          ansible_ssh_user: "{{ansible_user}}"
+          ansible_ssh_private_key_file: "{{private_key_path}}/{{di_output_json | json_query('_meta.hostvars.\"' + item + '\".openstack.key_name')}}.pem"
+        with_items: "{{zookeeper_nodes}}"
+      when: not (inventory_type is undefined or inventory_type == "static") and cloud == "osp"
+      run_once: true
+
+# If we're running this command for to build a cluster in an AWS or
+# OpenStack cloud, then use the `ec2` or `openstack` command to (depending
+# on the `cloud` we're deploying to) gather the dynamic inventory information
+# that we need to build our Solr host group (and build it)
+- name: Create Solr host group from AWS or OpenStack inventory
+  hosts: "{{host_inventory}}"
+  gather_facts: no
+  tasks:
+    # run these commands to add the Solr host group for an aws cloud
+    - block:
+      - set_fact:
+          application_nodes: "{{di_output_json | json_query('tag_Application_' + application)}}"
+      - set_fact:
+          solr_nodes: "{{cloud_nodes | intersect(tenant_nodes) | intersect(project_nodes) | intersect(domain_nodes) | intersect(application_nodes)}}"
+      - add_host:
+          name: "{{item}}"
+          groups: "solr"
+          ansible_ssh_user: "{{ansible_user}}"
+          ansible_ssh_private_key_file: "{{private_key_path}}/{{cloud}}-{{di_output_json | json_query('_meta.hostvars.\"' + item + '\".ec2_key_name')}}-private-key.pem"
+        with_items: "{{solr_nodes}}"
+      when: not (inventory_type is undefined or inventory_type == "static") and cloud == "aws"
+      run_once: true
+    # or run these commands to add the Solr host group for an osp cloud
+    - block:
+      - set_fact:
+          application_nodes: "{{(di_output_json | json_query('[\"meta-Application_' + application + '\"]')).0}}"
+      - set_fact:
+          solr_nodes: "{{cloud_nodes | intersect(tenant_nodes) | intersect(project_nodes) | intersect(domain_nodes) | intersect(application_nodes)}}"
+      - add_host:
+          name: "{{item}}"
+          groups: "solr"
+          ansible_ssh_user: "{{ansible_user}}"
+          ansible_ssh_private_key_file: "{{private_key_path}}/{{di_output_json | json_query('_meta.hostvars.\"' + item + '\".openstack.key_name')}}.pem"
+        with_items: "{{solr_nodes}}"
+      when: not (inventory_type is undefined or inventory_type == "static") and cloud == "osp"
+      run_once: true
+
+# Otherwise, build our Zookeeper host group from the static inventory
+# information that was passed in
+- name: Create Zookeeper host group from input zookeeper_nodes list
+  hosts: "{{host_inventory}}"
+  gather_facts: no
+  tasks:
+    - add_host:
+        name: "{{item}}"
+        groups: "zookeeper"
+        ansible_ssh_host: "{{((zookeeper_inventory|default(item)).item | default(item)).ansible_ssh_host | default(item)}}"
+        ansible_ssh_port: "{{((zookeeper_inventory|default(22)).item | default(22)).ansible_ssh_port | default(22)}}"
+        ansible_ssh_user: "{{((zookeeper_inventory|default(ansible_user)).item | default(ansible_user)).ansible_ssh_user | default(ansible_user)}}"
+        ansible_ssh_private_key_file: "{{((zookeeper_inventory|default(ansible_ssh_private_key_file)).item | default(ansible_ssh_private_key_file)).ansible_ssh_private_key_file | default(ansible_ssh_private_key_file)}}"
+      with_items: "{{zookeeper_nodes | default([])}}"
+      when: inventory_type == "static"
+      run_once: true
+
+# And build our Solr host group from the static inventory
+# information that was passed in
+- name: Create Solr host group from input host_inventory list
+  hosts: "{{host_inventory}}"
+  gather_facts: no
+  tasks:
+    - add_host:
+        name: "{{item}}"
+        groups: "solr"
+      with_items: "{{host_inventory}}"
+      when: inventory_type == "static"
+      run_once: true
+
+# Collect some Zookeeper related facts and determine the "private" IP addresses of
+# the nodes in the Zookeeper ensemble (from their "public" IP addresses and the `solr_iface`
+# variable that was passed in as part of this playbook run) if a list of "public"  Zookeeper
+# IP addresses was passed in.
+- name: Gather facts from Zookeeper host group (if defined)
+  hosts: zookeeper
+  tasks: []
+
+# Then, deploy Solr (Fusion) to the nodes in the `host_inventory` that was passed in (if there
+# is more than one node passed in, those nodes will be configured as a single Solr cluster)
+- name: Install/configure Solr server(s)
+  hosts: solr
+  gather_facts: no
   vars_files:
     - vars/solr.yml
   vars:
     - combined_package_list: "{{ (default_packages|default([])) | union(solr_package_list) | union((install_packages_by_tag|default({})).solr|default([])) }}"
+  # First, determine what the "private" IP addresses of the Zookeeper ensemble are from
+  # the "public" IP addresses that were passed in for this ensemble and the interface name
+  # that we'll be configuring Solr to listen on.  Once that's done, ensure that all of the
+  # interfaces on the Solr node(s) are up by restarting the network, then gather the facts
+  # from our Solr node(s)
+  pre_tasks:
+    - set_fact:
+        zk_nodes: "{{zookeeper_nodes | map('extract', hostvars, [('ansible_' + solr_iface), 'ipv4', 'address']) | list}}"
+    - name: Ensure the network interfaces are up on our Solr node(s)
+      service:
+        name: network
+        state: restarted
+      become: true
+    - name: Gather facts from the Solr node(s)
+      setup:
+  # Now that we have all of the facts we need, run the roles that are used to
+  # deploy and configure Solr
   roles:
-    - role: ensure-interfaces-up
     - role: get-iface-addr
       iface_name: "{{solr_iface}}"
     - role: setup-web-proxy

--- a/tasks/enable-solr-services.yml
+++ b/tasks/enable-solr-services.yml
@@ -2,4 +2,6 @@
 ---
 - name: Enable fusion services on boot
   become: true
-  command: systemctl enable fusion
+  service:
+    name: fusion
+    enabled: yes

--- a/tasks/setup-solr-server-properties.yml
+++ b/tasks/setup-solr-server-properties.yml
@@ -22,24 +22,24 @@
     lineinfile:
       dest: "{{full_solr_dir}}/conf/fusion.properties"
       regexp: "^FUSION_ZK="
-      line: "FUSION_ZK={{(zookeeper_nodes | default([])) | join(':2181,')}}:2181"
+      line: "FUSION_ZK={{(zk_nodes | default([])) | join(':2181,')}}:2181"
   - name: Set local address to address of NIC that Solr should listen on
     lineinfile:
       dest: "{{full_solr_dir}}/conf/fusion.properties"
       regexp: "^(#)?default.address ="
-      line: "default.address = {{iface_addr}}"
+      line: "default.address = {{solr_addr}}"
   - name: Define ZK Connect address for Solr
     lineinfile:
       dest: "{{full_solr_dir}}/conf/fusion.properties"
       regexp: "^(# )?default.zk.connect ="
-      line: "default.zk.connect = {{(zookeeper_nodes | default([])) | join(':2181,')}}:2181"
+      line: "default.zk.connect = {{(zk_nodes | default([])) | join(':2181,')}}:2181"
   - name: Disable startup of local Zookeeper instance
     replace:
       dest: "{{full_solr_dir}}/conf/fusion.properties"
       regexp: '^(.*)zookeeper, (.*)$'
       replace: '\g<1>\g<2>'
   become: true
-  when: (zookeeper_nodes | default([])) != []
+  when: (zk_nodes | default([])) != []
 # setup the garbage collection option we want to use
 - name: Change garbage algorithm used to the 'g1' algorithm
   lineinfile:
@@ -108,4 +108,4 @@
       regexp: "^dataDir="
       line: "dataDir={{solr_data_dir}}/zookeeper"
   become: true
-  when: (zookeeper_nodes | default([])) == []
+  when: (zk_nodes | default([])) == []

--- a/tasks/start-solr-services.yml
+++ b/tasks/start-solr-services.yml
@@ -1,5 +1,7 @@
 # (c) 2016 DataNexus Inc.  All Rights Reserved
 ---
 - name: Start fusion service
-  command: systemctl start fusion
   become: true
+  service:
+    name: fusion
+    state: restarted

--- a/vars/solr.yml
+++ b/vars/solr.yml
@@ -30,3 +30,6 @@ solr_package_list: ["java-1.8.0-openjdk", "java-1.8.0-openjdk-devel"]
 # used to install Fusion (Solr) from a local (to the Ansible node) gzipped
 # tarfile (if it exists)
 local_solr_file: ""
+
+# path used to access private keys (defaults to the current working directory)
+private_key_path: "."


### PR DESCRIPTION
The changes in this pull request add support for the use of dynamic inventory scripts (for both OpenStack and AWS) when deploying a Fusion (Solr) cluster.  Specifically:

* Adds a new `common-utils` submodule to the repository that contains the shell scripts that are used to gather dynamic inventory information from AWS and OpenStack
* Adds a couple of new options to the `Vagrantfile` that can be used to define the inventory file that contains the information needed to connect to an (external) zookeeper ensemble (in the case where we're creating a Solr cluster using `vagrant`) and to clear the existing proxy settings from the target machines if a proxy was defined in a previous run and is not defined in the current run (this parameter defaults to `false`, leaving any existing proxy information in place)
* Modifies the playbook in the `site.yml` file to support deployments to either
    1.  AWS and OpenStack using the new dynamic inventory scripts (and assuming that the machines being used in the deployment are tagged appropriately by `cloud`, `tenant`, `project`, `domain`, and `application`) or 
    1. a set of nodes defined via a static inventory hash map containing the node IP addresses as keys and a nested hash map containing the the parameters needed to connect to that node as key-value pairs under those IP addresses
* Modifies the `.gitignore` file to ignore `pem` files (for those cases where a PEM file is saved locally for use in dynamic inventory driven deployments)
* Adds a new `private_key_path` parameter to the `vars/solr.yml` file that is used to determine where the private keys used to access the nodes are located (this parameter defaults to the current working directory but it can be set to any directory on the system)

The changes in this repository have been tested using multi-node (clustered) deployments to both AWS and OpenStack and using a single-node deployment test under Vagrant