### PR TITLE
Adds support for separation of the api and data network

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -123,7 +123,7 @@
       run_once: true
 
 # Collect some Zookeeper related facts and determine the "private" IP addresses of
-# the nodes in the Zookeeper ensemble (from their "public" IP addresses and the `solr_iface`
+# the nodes in the Zookeeper ensemble (from their "public" IP addresses and the `data_iface`
 # variable that was passed in as part of this playbook run) if a list of "public"  Zookeeper
 # IP addresses was passed in.
 - name: Gather facts from Zookeeper host group (if defined)
@@ -146,7 +146,7 @@
   # from our Solr node(s)
   pre_tasks:
     - set_fact:
-        zk_nodes: "{{zookeeper_nodes | map('extract', hostvars, [('ansible_' + solr_iface), 'ipv4', 'address']) | list}}"
+        zk_nodes: "{{(zookeeper_nodes | default([])) | map('extract', hostvars, [('ansible_' + data_iface), 'ipv4', 'address']) | list}}"
     - name: Ensure the network interfaces are up on our Solr node(s)
       service:
         name: network
@@ -158,12 +158,15 @@
   # deploy and configure Solr
   roles:
     - role: get-iface-addr
-      iface_name: "{{solr_iface}}"
+      iface_name: "{{data_iface}}"
+      as_fact: "data_addr"
+    - role: get-iface-addr
+      iface_name: "{{api_iface}}"
+      as_fact: "api_addr"
     - role: setup-web-proxy
     - role: add-local-repository
-      yum_repository: "{{yum_repo_addr}}"
-      when: yum_repo_addr is defined
+      yum_repository: "{{yum_repo_url}}"
+      when: yum_repo_url is defined
     - role: install-packages
       package_list: "{{combined_package_list}}"
     - role: dn-solr
-      solr_addr: "{{iface_addr}}"

--- a/tasks/install-lucidworks-fusion.yml
+++ b/tasks/install-lucidworks-fusion.yml
@@ -27,6 +27,7 @@
     copy:
       src: "{{local_solr_file}}"
       dest: "/tmp"
+      mode: 0644
   - set_fact:
       local_filename: "{{local_solr_file | basename}}"
   when: install_from_dir

--- a/tasks/setup-solr-server-properties.yml
+++ b/tasks/setup-solr-server-properties.yml
@@ -23,11 +23,6 @@
       dest: "{{full_solr_dir}}/conf/fusion.properties"
       regexp: "^FUSION_ZK="
       line: "FUSION_ZK={{(zk_nodes | default([])) | join(':2181,')}}:2181"
-  - name: Set local address to address of NIC that Solr should listen on
-    lineinfile:
-      dest: "{{full_solr_dir}}/conf/fusion.properties"
-      regexp: "^(#)?default.address ="
-      line: "default.address = {{solr_addr}}"
   - name: Define ZK Connect address for Solr
     lineinfile:
       dest: "{{full_solr_dir}}/conf/fusion.properties"
@@ -40,12 +35,35 @@
       replace: '\g<1>\g<2>'
   become: true
   when: (zk_nodes | default([])) != []
-# setup the garbage collection option we want to use
-- name: Change garbage algorithm used to the 'g1' algorithm
-  lineinfile:
-    dest: "{{full_solr_dir}}/conf/fusion.properties"
-    regexp: "^default.gc ="
-    line: "default.gc = g1"
+# change the address where that the Fusion server listens on
+# for client connections as well as the address where the Fusion
+# server's UI is listening
+- block:
+  - name: Set default address and bind address to address of NIC that Fusion should listen on
+    lineinfile:
+      dest: "{{full_solr_dir}}/conf/fusion.properties"
+      regexp: "^(#)?default.{{item}} ="
+      line: "default.{{item}} = {{api_addr}}"
+    with_items:
+      - address
+      - bindAddress
+  - name: Set Solr address and bind address to address of NIC that Solr should listen on
+    lineinfile:
+      dest: "{{full_solr_dir}}/conf/fusion.properties"
+      regexp: "^(#)?solr.{{item}} ="
+      line: "solr.{{item}} = {{data_addr}}"
+    with_items:
+      - address
+      - bindAddress
+  - name: Set Zookeeper address and bind address when creating a local Zookeeper instance
+    lineinfile:
+      dest: "{{full_solr_dir}}/conf/fusion.properties"
+      regexp: "^(#)?zookeeper.{{item}} ="
+      line: "zookeeper.{{item}} = {{data_addr}}"
+    with_items:
+      - address
+      - bindAddress
+    when: (zk_nodes | default([])) == []
   become: true
 # if a `solr_data_dir` value was passed in, then ensure that directory
 # exists, move the contents of the default directory over to that

--- a/vars/solr.yml
+++ b/vars/solr.yml
@@ -12,8 +12,13 @@ solr_url: "https://download.lucidworks.com/fusion-3.0.0.tar.gz"
 # the directory where the solr data will be written
 solr_data_dir: /opt/lucidworks/data
 
-# the interface Fusion (Solr) should listen on when running
-solr_iface: eth0
+# the names of the interfaces to use for the Fusion (Solr) services;
+# the "data" interface is the private interface that is used to communicate
+# with other members of the cluster (and Zookeeper), while the "api"
+# interface is the interface that the Fusion servers listen on for connections
+# from clients
+api_iface: "eth0"
+data_iface: "eth0"
 
 # the directory that the distribution should be unpacked into
 solr_dir: "/opt/lucidworks"


### PR DESCRIPTION
The changes in this pull request modify the existing playbook; adding support for separation between a private network (the data network used by the cluster to communicate) and a public network (the API network that the cluster listens on for client connections). In situations where this separation is not important, the two parameters used to define these networks can simply be set to the same network interface, eg. `eth0` (in fact, this is how the defaults defined in the `vars/solr.yml` file are setup).

This pull request also includes a fix for a of minor bug (involving the permissions set when the solr distribution files are copied over from the Ansible host) that was discovered when deploying Solr to a RHEL OSP cluster recently.

Finally, this pull request also contains a separate (unrelated) change to how a local mirror is passed into the playbook (in situations where access to the standard yum repositories is not possible). The mirror is now defined as a URL instead of a hostname/IP address (to reflect recent changes in the underlying `common-roles/add-local-repository` role). This should make it easier to support whatever directory structure was used when defining the local mirror.