### PR TITLE
Adds code to support RHEL testing

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -17,7 +17,7 @@
       vars:
         host_group_list:
           - { name: solr, node_list: "{{host_inventory}}" }
-          - { name: zookeeper, inventory: "{{zookeeper_inventory}}", node_list: "{{zookeeper_nodes}}" }
+          - { name: zookeeper, inventory: "{{zookeeper_inventory | default({})}}", node_list: "{{zookeeper_nodes | default([])}}" }
       when: cloud == "vagrant"
 
 # Collect some Zookeeper related facts and determine the "private" IP addresses of
@@ -43,8 +43,6 @@
   # interfaces on the Solr node(s) are up by restarting the network, then gather the facts
   # from our Solr node(s)
   pre_tasks:
-    - set_fact:
-        zk_nodes: "{{(zookeeper_nodes | default([])) | map('extract', hostvars, [('ansible_' + data_iface), 'ipv4', 'address']) | list}}"
     - name: Ensure the network interfaces are up on our Solr node(s)
       service:
         name: network
@@ -52,6 +50,30 @@
       become: true
     - name: Gather facts from the Solr node(s)
       setup:
+    # in these two steps, we obtain the interface names for our data_iface
+    # and api_iface (provided an interface description was provided for each)
+    - include_role:
+        name: get-iface-names
+      vars:
+        iface_descriptions: "{{iface_description_array}}"
+      when: not (iface_description_array is undefined or iface_description_array == [])
+    # and now that we know we have our data_iface identified, we can construct
+    # the list of zk_nodes (the data_iface IP addresses of our zookeeper_nodes)
+    - set_fact:
+        zk_nodes: "{{(zookeeper_nodes | default([])) | map('extract', hostvars, [('ansible_' + data_iface), 'ipv4', 'address']) | list}}"
+    # if we're provisioning a RHEL machine, then we need to ensure that
+    # it's subscribed before we can install anything (if it hasn't been
+    # registered already, of course, if that's the case then we can skip
+    # this step)
+    - block:
+      - redhat_subscription:
+          state: present
+          username: "{{rhel_username}}"
+          password: "{{rhel_password}}"
+          consumer_id: "{{rhel_consumer_id}}"
+        become: true
+        when: rhel_username is defined and rhel_password is defined and rhel_consumer_id is defined
+      when: ansible_distribution == 'RedHat'
   # Now that we have all of the facts we need, run the roles that are used to
   # deploy and configure Solr
   roles:
@@ -64,7 +86,7 @@
     - role: setup-web-proxy
     - role: add-local-repository
       yum_repository: "{{yum_repo_url}}"
-      when: yum_repo_url is defined
+      when: yum_repo_url is defined and ansible_distribution != 'RedHat'
     - role: install-packages
       package_list: "{{combined_package_list}}"
     - role: dn-solr

--- a/site.yml
+++ b/site.yml
@@ -37,17 +37,15 @@
     - vars/solr.yml
   vars:
     - combined_package_list: "{{ (default_packages|default([])) | union(solr_package_list) | union((install_packages_by_tag|default({})).solr|default([])) }}"
-  # First, determine what the "private" IP addresses of the Zookeeper ensemble are from
-  # the "public" IP addresses that were passed in for this ensemble and the interface name
-  # that we'll be configuring Solr to listen on.  Once that's done, ensure that all of the
-  # interfaces on the Solr node(s) are up by restarting the network, then gather the facts
-  # from our Solr node(s)
+  # First, restart the network (unless the skip_network_restart was set)
+  # and gather some facts about our Solr node(s)
   pre_tasks:
     - name: Ensure the network interfaces are up on our Solr node(s)
       service:
         name: network
         state: restarted
       become: true
+      when: not (skip_network_restart is defined or skip_network_restart)
     - name: Gather facts from the Solr node(s)
       setup:
     # in these two steps, we obtain the interface names for our data_iface


### PR DESCRIPTION
This pull request adds some changes to the `Vagrantfile` and the playbook in the associated `site.yml` file that make it easier to test Solr (Fusion) deployments onto RHEL7 VMs under Vagrant.  Specifically:

* the `Vagrantfile` now includes an example (commented out for now) of the configuration option needed to create a VM based on a RHEL7 box file instead of the CentOS7 box file we've been using to date
* the playbook in the associated `site.yml` file includes a task that uses the `redhat_subscription` module to register the RHEL7 instance (if we're deploying a RHEL7-based VM) to register that instance using the input `rhel_username`, `rhel_password`, and `rhel_consumer_id` parameters (these parameters are, of course, left unspecified and must be supplied somehow at runtime as extra variables when the playbook is run).
* a section has been added to the playbook that uses the new `get-iface-name` role (from the latest version of the `common-roles` repository) to retrieve the name of an interface using an associated description hash that consists of a type (`cidr` in this case) and a value (the CIDR for the network you want the name of); the resulting network name is saved locally and used later in the playbook.  This mechanism for obtaining the interface name is actually much simpler than passing in the name of the interface on many platforms (like recent versions of RHEL) where the naming convention for NICs is harder to guess before the OS is provisioned.
* the `data_iface_desc` and `api_iface_desc` external variables were added to the `Vagrantfile` (each pointing to a hash containing a type (cidr) and value (the CIDR for that network); the corresponding `data_iface` and `api_iface` external variables were left in place but commented out to show that they could be used as an alternative (if the interface names are known).
* a default has been added to the `host_group_list` that is used in the static inventory use case to handle situations where a `zookeeper_inventory` hash and a `zookeeper_nodes` host list were not provided
* a few default parameters that were added in a recent commit `vars/solr.yml` file are overridden in the `Vagrantfile` so that the `Vagrantfile` can be used to deploy Solr/Fusion to a reasonably sized VM for local testing (in the recent commit, for example, the default minimum and maximum heap size for the Java process that runs the Solr server was set to 16GB, and another 3G, minimum, is required for the Connectors Java process).
* the `common-roles` submodule has been updated to the latest version and an additional test has been added to the call out to the `add-local-repository` role (to skip this when deploying Solr/Fusion to a RedHat OS instance, since the local repository role really only works for CentOS-based OS instances).

With these changes in place, the current repository can be used to deploy to both RHEL7 and CentOS7 based VMs using `vagrant`.